### PR TITLE
compatibility: bump release CI to github-workflows @v1.4

### DIFF
--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       environment: Prod
 
   deploy:
-    uses: wpconnect-co/public-github-workflows/.github/workflows/deploy-to-wordpress.yml@v1.3
+    uses: wpconnect-co/public-github-workflows/.github/workflows/deploy-to-wordpress.yml@v1.4
     needs: auto-tag-and-release
     secrets: inherit
     with:

--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   auto-tag-and-release:
     if: github.event.pull_request.merged == true && 'main' == github.event.pull_request.base.ref && startsWith(github.event.pull_request.head.ref, 'release/')
-    uses: wpconnect-co/public-github-workflows/.github/workflows/auto-tag-and-release.yml@v1.3
+    uses: wpconnect-co/public-github-workflows/.github/workflows/auto-tag-and-release.yml@v1.4
     permissions:
       contents: write
     with:


### PR DESCRIPTION
Bumps `.github/workflows/tag-and-deploy.yml` from `@v1.3` to `@v1.4` for both reusable workflows (`auto-tag-and-release`, `deploy-to-wpconnect`).

**Why:** `v1.3`'s "Install WP-CLI" step runs `wp package install wp-cli/dist-archive-command` unpinned, resolving to `dev-main`, which now requires `wp-cli/wp-cli ^2.13`. The runner's stable `wp-cli.phar` is 2.12.0, so Composer cannot resolve and the release job fails before building the archive. This already broke GF Brevo 2.9.0 (addon_gf-sib) and will break the next release of every plugin still on `@v1.3`.

`v1.4` pins `wp-cli/dist-archive-command:3.1.0` (requires `wp-cli ^2`, satisfied by 2.12.0), fixing the release/deploy pipeline.

Safe to merge now: the head branch is not `release/*`, so this does **not** trigger any tag/release/deploy. It only changes which reusable-workflow version the *next* release will use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)